### PR TITLE
Add anti-shake feaure for MacOS

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,7 @@
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import Mira, { REFRESH_MODE } from '../src/mira.js';
+import Mira, { AUTO_DITHER_MODE, REFRESH_MODE } from '../src/mira.js';
 
 const mira = Mira.create();
 if (!mira) {
@@ -13,6 +13,9 @@ if (!mira) {
 await yargs(hideBin(process.argv))
   .command('refresh', 'refresh the screen', () => { }, async () => {
     await mira.refresh();
+  })
+  .command('antishake', 'anti-shake automatically', () => { }, async () => {
+    await mira.setAutoDitherMode(AUTO_DITHER_MODE.high);
   })
   .command('settings', 'apply settings', {
     speed: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boox-mira",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "boox-mira",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "node-hid": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boox-mira",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "A library for interacting with the Boox Mira",
   "license": "GPL-3.0-or-later",

--- a/src/mira.js
+++ b/src/mira.js
@@ -18,12 +18,20 @@ const OP_CODE = {
   set_warm_light: 0x07,
   set_dither_mode: 0x09,
   set_color_filter: 0x11,
+  set_auto_dither_mode: 0x12,
 };
 
 export const REFRESH_MODE = {
   direct_update: 0x01, // black/white, fast
   gray_update: 0x02, // gray scale, slow
   a2: 0x03, // fast
+};
+
+export const AUTO_DITHER_MODE = {
+  disable: [0, 0, 0, 0],
+  low: [1, 0, 30, 10],
+  middle: [1, 0, 40, 10],
+  high: [1, 0, 50, 30],
 };
 
 const USB_REPORT_ID = 0x00;
@@ -63,6 +71,17 @@ export default class Mira {
 
   async refresh() {
     await this.write([USB_REPORT_ID, OP_CODE.refresh]);
+  }
+
+  async setAutoDitherMode(autoDitherMode) {
+    await this.write([
+      USB_REPORT_ID,
+      OP_CODE.set_auto_dither_mode,
+      autoDitherMode[0],
+      autoDitherMode[1],
+      autoDitherMode[2],
+      autoDitherMode[3],
+    ]);
   }
 
   async setSpeed(speed) {


### PR DESCRIPTION
Hi, @ipodnerd3019 

Thank you for creating this great tool!

I am using Mira 13" monitor with Mac Studio. For new M1, M2 CPU computers, it seems that there's display optimization that cause Mira monitor blinking a lot. In Mira's official utility, it added an anti-shaking feature to reduce the blinking. I would like to have this option added to `mira-js` too. 

My current implementation is just to disable and enable the anti-shaking with single command `npx mira antishaking`. That's just exactly what I need to do every time I connect my Mira Monitor to Mac Studio. If this command could be added into `Mira-js`, it could help other Mira users too. :)

![image](https://user-images.githubusercontent.com/4084738/214070343-cbc8776e-350d-4da9-bebc-fb79d5b66c9d.png)
